### PR TITLE
🐛 fix(inngest): fix date formatting for daily news summary

### DIFF
--- a/lib/inngest/functions.ts
+++ b/lib/inngest/functions.ts
@@ -132,7 +132,7 @@ export const sendDailyNewsSummary = inngest.createFunction(
 
         return await sendNewsSummaryEmail({
           email: user.email,
-          date: formatDateToday, 
+          date: formatDateToday(), 
           newsContent
         })
       }))

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -116,7 +116,7 @@ export const formatPrice = (price: number) => {
   }).format(price);
 };
 
-export const formatDateToday = new Date().toLocaleDateString('en-US', {
+export const formatDateToday = () => new Date().toLocaleDateString('en-US', {
   weekday: 'long',
   year: 'numeric',
   month: 'long',


### PR DESCRIPTION
- 【Bug Fix】: The `formatDateToday` function was being called incorrectly, resulting in the same date being used for all emails.
- 【Reasoning】: Changed `formatDateToday` from a constant to a function call to ensure the current date is used when sending daily news summaries.